### PR TITLE
rails5対応

### DIFF
--- a/lib/url_for.rb
+++ b/lib/url_for.rb
@@ -6,7 +6,7 @@ module ActionDispatch
     class RouteSet
 
       # Add a secure option to the rewrite method.
-      def url_for_with_secure_option(options = {})
+      def url_for_with_secure_option(options = {}, *args)
         secure = options.delete(:secure)
 
         # if secure && ssl check is not disabled, convert to full url with https
@@ -30,18 +30,18 @@ module ActionDispatch
           end
         end
 
-        url_for_without_secure_option(options)
+        url_for_without_secure_option(options, *args)
       end
 
       # if full URL is requested for http and we've been told to use a
       # non-ssl host override, then use it
-      def url_for_with_non_ssl_host(options)
+      def url_for_with_non_ssl_host(options, *args)
         if !options[:only_path] && !SslRequirement.non_ssl_host.nil?
           if !(/^https/ =~ (options[:protocol] || @request.try(:protocol)))
             options.merge! :host => SslRequirement.non_ssl_host
           end
         end
-        url_for_without_non_ssl_host(options)
+        url_for_without_non_ssl_host(options, *args)
       end
 
       # want with_secure_option to get run first (so chain it last)


### PR DESCRIPTION
rails5にすると下記エラーになって動かなかったので対応しているコミットを探してました。

```
 :009 > app.ranking_path
ArgumentError: wrong number of arguments (given 3, expected 0..1)
        from /Users/koji/sites/outing/vendor/bundler/ruby/2.3.0/bundler/gems/ssl_requirement-a039364df143/lib/url_for.rb:9:in `url_for_with_secure_option'
        from /Users/koji/sites/outing/vendor/bundler/ruby/2.3.0/gems/actionpack-5.0.0.1/lib/action_dispatch/routing/route_set.rb:236:in `call'
        from /Users/koji/sites/outing/vendor/bundler/ruby/2.3.0/gems/actionpack-5.0.0.1/lib/action_dispatch/routing/route_set.rb:295:in `block (2 levels) in define_url_helper'
        from (irb):9
        from /Users/koji/sites/outing/vendor/bundler/ruby/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/console.rb:65:in `start'
        from /Users/koji/sites/outing/vendor/bundler/ruby/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/console_helper.rb:9:in `start'
        from /Users/koji/sites/outing/vendor/bundler/ruby/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb:78:in `console'
        from /Users/koji/sites/outing/vendor/bundler/ruby/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
        from /Users/koji/sites/outing/vendor/bundler/ruby/2.3.0/gems/railties-5.0.0.1/lib/rails/commands.rb:18:in `<top (required)>'
        from bin/rails:4:in `require'
        from bin/rails:4:in `<main>'
```

forkしているリポジトリで対応コミットがあったのでこちら取り込みました。
https://github.com/szalansky/ssl_requirement/commit/adb1e7d9ff66adab448b287ebdca25199afbd7de

本変更を取り込んだところraiis5で動くようになりました。
レビューお願いいます。
